### PR TITLE
Proposal for ceenter metadata variables structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,61 @@
-Ceenter is Awesome!
+# Ceenter
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [Ceenter](#ceenter)
+    - [Metadata for VM Creation](#metadata-for-vm-creation)
+        - [Ansible naming convention](#ansible-naming-convention)
+            - [Ansible Playbook names](#ansible-playbook-names)
+            - [Ansible Playbook Variable names](#ansible-playbook-variable-names)
+            - [Ansible role variable names](#ansible-role-variable-names)
+    - [Local setup](#local-setup)
+        - [Prerequisites](#prerequisites)
+        - [Install Ansible collections](#install-ansible-collections)
+        - [Create VM on GCP](#create-vm-on-gcp)
+    - [Ansible Tower](#ansible-tower)
+        - [Tower setup](#tower-setup)
+        - [OpenShift setup](#openshift-setup)
+    - [Api Caller](#api-caller)
+
+<!-- markdown-toc end -->
+
+## Metadata for VM Creation
+
+### Ansible naming convention
+
+#### Ansible Playbook names
+
+**Playbook names** are in form of:
+
+*<requesttype>-<servicetype>-<platform>-<operation>.yml*
+
+Example: Create VM on GCP platform
+
+*Service-VM-GCP-Create.yml*
+
+#### Ansible Playbook Variable names
+
+Convention for ceenter external Ansible variable prefixes:
+
+| prefix        | purpose                     |
+|---------------|-----------------------------|
+| `ceenter_`    | Prefix all variables        |
+| `ceenter_vm_` | Prefix for VM related roles |
+
+Ceenter metadata variables for VM Creation:
+
+| variable                    | default value | options                        | purpose                     |
+|-----------------------------|---------------|--------------------------------|-----------------------------|
+| `ceenter_vm_image`          | centos8       | rhel7, rhel8, centos7, centos8 | Prefix for VM related roles |
+| `ceenter_vm_flavor`         | small         | small, medium, large           | Prefix for VM related roles |
+| `ceenter_vm_disk_size_gb`   | 30            | number                         | Prefix for VM related roles |
+| `ceenter_vm_storage_flavor` | standard      | standard, performance          | Prefix for VM related roles |
+| `ceenter_vm_region`         | standard      | standard, performance          | Prefix for VM related roles |
+
+#### Ansible role variable names
+
+Role variable names should be in form: `<role_name>_*`, so for example disk size in *gcp_vm* role will be defined as `gcp_vm_disk_size_gb`.
 
 ## Local setup
 
@@ -102,7 +159,3 @@ Container image is build in [ansible-runner-images repository](https://github.co
 
 The API Caller is an example GUI which helps generating the propoer API syntax. Ultimately it may also execute the API call, but not at this stage yet.
 The metdata for API Caller is under the api-caller folder. The first file is the menu-map.json where the interactive menu options are defined.
-
-
-
-


### PR DESCRIPTION
Declare general metadata used for VM creation that will be supported
by roles for creating VMs in specific environments, e.g. RHV, GCP, Azure.