### PR TITLE
Newly created GCP instances are accessible via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,20 @@ Download [GCP credentials](https://docs.ansible.com/ansible/latest/scenario_guid
 ### Create VM on GCP
 
 ``` shell
-ansible-playbook GCP_VM_Create.yml
+ansible-playbook Service-GCP-VM-Create.yml
 ```
-
 
 ### Manual Tower setup ###
 
-Create Credential:
+Configure GCP:
+- [Create GCP account](https://docs.ansible.com/ansible/latest/scenario_guides/guide_gce.html#credentials)
+- Create [keys for ssh access](https://cloud.google.com/compute/docs/instances/ssh#third-party-tools) to GCP VMs
+  - [Generate SSH Keys](https://cloud.google.com/compute/docs/instances/adding-removing-ssh-keys#createsshkeys)
+        ssh-keygen -t rsa -f ~/.ssh/gcloud-ansible -C ansible
+
+Create Credentials:
 - GCP connection
+- GCP machine type for ssh access
 - Github
 - RHV
 
@@ -169,7 +175,9 @@ Parameters: {"vm_name":"mytest","vm_flavor":"Small","vm_memory":2,"vm_cpu":1,"vm
 ```
 
 
-## OpenShift setup ##
+## Environment Setup ##
+
+### OpenShift setup ###
 
 Additional Container Group on OpenShift
 - `oc create -n tower -f ocp-setup/role-pod-manager.yml`

--- a/roles/gcp_vm/defaults/main.yml
+++ b/roles/gcp_vm/defaults/main.yml
@@ -11,3 +11,5 @@ gcp_vm_flavor: "{{ vm_flavor_options[ vm_flavor | lower ] }}"
 gcp_vm_disk_name: "{{ vm_name }}-disk"
 gcp_vm_address_name: "{{ vm_name }}-address"
 gcp_vm_os_image: "{{ gcp_vm_os_images[vm_os_version] }}"
+
+gcp_vm_ansible_user_ssh_pub_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDKFI6svQaF6PiiVPvJDRVL+gSZmaPKVfMPhvMygmc9mqmf1fdszFHueF+phfY+YCc1SeuXnqFd3rcdItmpIcq46yzdRK9dZkI/p6VHWXno9a/neTIlBT71SI/hxrFKHxPaplrSeyfjSeO3+IWgn3l56GuaRG+nXRsz+AYFQqLUqDptmeTNu/PVJiMuzZY/kwVOrFvrj/hrEVLMVrnK9KLDirxAPUbHWiXTuviPkK0Q7lk8ONZEa7zABDNA3oLC92hTg2y9p+hPLfl2UV4bnPx6Gl+iSVpBIU9E6VN2nRmXGd9QzyB0v3GqxY8JHlFN1WogZlop3blFu6yzQ1Oq3kN0oVcoD7hZP8KuqkY/I4lCSslXJ3IXpCoUld6e+Ys39CmBmqc4wgCDqcUfOat2tbNHj0wxRtn2fjs3dyM0EeIQG1MJA4zre6xkulQcAsu+JfEUIImKx2H0odkbvKnXj8nKCqTwe6OEf8fpeKGtuNSl1QSJFcWhFeAiJ7cPl+s3z3c= ansible

--- a/roles/gcp_vm/defaults/main.yml
+++ b/roles/gcp_vm/defaults/main.yml
@@ -3,9 +3,11 @@
 vm_name: test
 vm_flavor: Small
 vm_disk_size: 20
+vm_os_version: centos-8
 
 # Local role defaults
 gcp_vm_state_present: true
 gcp_vm_flavor: "{{ vm_flavor_options[ vm_flavor | lower ] }}"
 gcp_vm_disk_name: "{{ vm_name }}-disk"
 gcp_vm_address_name: "{{ vm_name }}-address"
+gcp_vm_os_image: "{{ gcp_vm_os_images[vm_os_version] }}"

--- a/roles/gcp_vm/tasks/create.yml
+++ b/roles/gcp_vm/tasks/create.yml
@@ -3,7 +3,7 @@
   gcp_compute_disk:
       name: "{{ gcp_vm_disk_name }}"
       size_gb: "{{ vm_disk_size }}"
-      source_image: 'projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts'
+      source_image: "{{ gcp_vm_os_image }}"
       zone: "{{ zone }}"
       project: "{{ gcp_project }}"
       state: present

--- a/roles/gcp_vm/tasks/create.yml
+++ b/roles/gcp_vm/tasks/create.yml
@@ -1,36 +1,36 @@
 ---
 - name: create a disk
   gcp_compute_disk:
-      name: "{{ gcp_vm_disk_name }}"
-      size_gb: "{{ vm_disk_size }}"
-      source_image: "{{ gcp_vm_os_image }}"
-      zone: "{{ zone }}"
-      project: "{{ gcp_project }}"
-      state: present
+    name: "{{ gcp_vm_disk_name }}"
+    size_gb: "{{ vm_disk_size }}"
+    source_image: "{{ gcp_vm_os_image }}"
+    zone: "{{ zone }}"
+    project: "{{ gcp_project }}"
+    state: present
   register: disk
 
 - name: create a address
   gcp_compute_address:
-      name: "{{ gcp_vm_address_name }}"
-      region: "{{ region }}"
-      project: "{{ gcp_project }}"
-      state: present
+    name: "{{ gcp_vm_address_name }}"
+    region: "{{ region }}"
+    project: "{{ gcp_project }}"
+    state: present
   register: address
 
 - name: create a instance
   gcp_compute_instance:
-      state: present
-      name: "{{ vm_name }}"
-      machine_type: "{{ gcp_vm_flavor }}"
-      disks:
-        - auto_delete: true
-          boot: true
-          source: "{{ disk }}"
-      network_interfaces:
-          - network: null # use default
-            access_configs:
-              - name: 'External NAT'
-                nat_ip: "{{ address }}"
-                type: 'ONE_TO_ONE_NAT'
-      zone: "{{ zone }}"
-      project: "{{ gcp_project }}"
+    state: present
+    name: "{{ vm_name }}"
+    machine_type: "{{ gcp_vm_flavor }}"
+    disks:
+      - auto_delete: true
+        boot: true
+        source: "{{ disk }}"
+    network_interfaces:
+      - network: null # use default
+        access_configs:
+          - name: 'External NAT'
+            nat_ip: "{{ address }}"
+            type: 'ONE_TO_ONE_NAT'
+    zone: "{{ zone }}"
+    project: "{{ gcp_project }}"

--- a/roles/gcp_vm/tasks/create.yml
+++ b/roles/gcp_vm/tasks/create.yml
@@ -22,6 +22,9 @@
     state: present
     name: "{{ vm_name }}"
     machine_type: "{{ gcp_vm_flavor }}"
+    metadata:
+      ssh-keys: |-
+        ansible:{{ gcp_vm_ansible_user_ssh_pub_key }}
     disks:
       - auto_delete: true
         boot: true
@@ -34,3 +37,14 @@
             type: 'ONE_TO_ONE_NAT'
     zone: "{{ zone }}"
     project: "{{ gcp_project }}"
+
+- name: Wait for SSH to come up
+  wait_for:
+    host: "{{ address.address }}"
+    port: 22
+    delay: 10
+    timeout: 60
+
+- name: Print host ready info
+  debug:
+    msg: "New server is ready, it may be accessed via ssh ansible@{{ address.address }}"

--- a/roles/gcp_vm/vars/main.yml
+++ b/roles/gcp_vm/vars/main.yml
@@ -3,3 +3,7 @@ vm_flavor_options:
   small: n1-standard-1
   medium: n1-standard-2
   large: n1-standard-4
+
+gcp_vm_os_images:
+  centos-8: 'projects/centos-cloud/global/images/family/centos-8'
+  centos-7: 'projects/centos-cloud/global/images/family/centos-7'

--- a/setup/tower/create_gcp_job_template.sh
+++ b/setup/tower/create_gcp_job_template.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# This script is creating surveys in job templates
+# To be rewritten to ansible later
+# Using .netrc file for authentication
+
+SURVEY_CREATE_SPEC_FILE="./data/gcp_vm_create_survey_spec.json"
+SURVEY_DELETE_SPEC_FILE="./data/gcp_vm_delete_survey_spec.json"
+TOWER_HOST=${TOWER_HOST-"https://localhost"}
+
+curl -X POST -H "Content-Type: application/json" -k -n ${TOWER_HOST}/api/v2/job_templates/Service-VM-GCP-Create/survey_spec/ -d @${SURVEY_CREATE_SPEC_FILE}
+
+curl -X POST -H "Content-Type: application/json" -k -n ${TOWER_HOST}/api/v2/job_templates/Service-VM-GCP-Delete/survey_spec/ -d @${SURVEY_DELETE_SPEC_FILE}

--- a/setup/tower/data/gcp_vm_create_survey_spec.json
+++ b/setup/tower/data/gcp_vm_create_survey_spec.json
@@ -8,7 +8,7 @@
       "type": "text"
     },
     {
-      "required": true,
+      "required": false,
       "variable": "vm_flavor",
       "question_description": "VM Flavor",
       "question_name": "VM Flavor",
@@ -17,11 +17,12 @@
       "type": "multiplechoice"
     },
     {
-      "required": true,
+      "required": false,
       "variable": "vm_disk_size",
       "question_description": "Disk size for new VM",
       "question_name": "Disk size",
       "type": "integer",
+      "default": 20,
       "min": 20,
       "max": 500
     }

--- a/setup/tower/data/gcp_vm_create_survey_spec.json
+++ b/setup/tower/data/gcp_vm_create_survey_spec.json
@@ -1,0 +1,31 @@
+{
+  "spec": [
+    {
+      "required": true,
+      "variable": "vm_name",
+      "question_description": "VM Name for new server",
+      "question_name": "VM Name",
+      "type": "text"
+    },
+    {
+      "required": true,
+      "variable": "vm_flavor",
+      "question_description": "VM Flavor",
+      "question_name": "VM Flavor",
+      "choices": "Small\nMedium\nLarge",
+      "default": "Small",
+      "type": "multiplechoice"
+    },
+    {
+      "required": true,
+      "variable": "vm_disk_size",
+      "question_description": "Disk size for new VM",
+      "question_name": "Disk size",
+      "type": "integer",
+      "min": 20,
+      "max": 500
+    }
+  ],
+  "description": "Input parameters for creating VM in GCP",
+  "name": "GCP VM Create"
+}

--- a/setup/tower/data/gcp_vm_delete_survey_spec.json
+++ b/setup/tower/data/gcp_vm_delete_survey_spec.json
@@ -1,0 +1,13 @@
+{
+  "spec": [
+    {
+      "required": true,
+      "variable": "vm_name",
+      "question_description": "VM Name for server to be deleted",
+      "question_name": "VM Name",
+      "type": "text"
+    }
+  ],
+  "description": "Input parameters for deleting VM in GCP",
+  "name": "GCP VM Delete"
+}


### PR DESCRIPTION
- update gcp instance metadata to include generated ansible pub key
  - users could possibly insert their pub key in future.
- enable internally multiple OSes, could be added as option from user input in future  
- document setting up GCP and Tower
- add scripts to update GCP Job surveys